### PR TITLE
Made name of tables components customizable

### DIFF
--- a/writehat/templates/componentTemplates/TableOfContents.html
+++ b/writehat/templates/componentTemplates/TableOfContents.html
@@ -1,5 +1,5 @@
 <section class="part{% if pageBreakBefore %} page-break{% endif %}" id="toc">
-{% include 'componentTemplates/Heading.html' with name="Table of Contents" %}
+{% include 'componentTemplates/Heading.html' %}
   <div id="table-of-contents">
     <ul class="toc-list">
       {% for component in toc_components %}

--- a/writehat/templates/componentTemplates/TableOfFigures.html
+++ b/writehat/templates/componentTemplates/TableOfFigures.html
@@ -1,5 +1,5 @@
 <section class="l{{ level }} component part {% if pageBreakBefore %} page-break {% endif %}" id="tof">
-{% include 'componentTemplates/Heading.html' with name="Table of Figures" %}
+{% include 'componentTemplates/Heading.html' %}
   <div id="table-of-figures">
     <ul class="tof-list">
       {% for figure in report.figures %}

--- a/writehat/templates/componentTemplates/TableOfTables.html
+++ b/writehat/templates/componentTemplates/TableOfTables.html
@@ -1,5 +1,5 @@
 <section class="l{{ level }} component part{% if pageBreakBefore %} page-break{% endif %}" id="tot">
-{% include 'componentTemplates/Heading.html' with name="Table of Tables" %}
+{% include 'componentTemplates/Heading.html' %}
 
   <div id="table-of-tables">
     <ul class="tot-list">


### PR DESCRIPTION
The title of the components Table of figures, Table of contents and Table of tables couldn't be customized as it was hard-coded in the template. It was problematic, especially for writing reports in languages other than English.