### PR TITLE
Restructure ToF component

### DIFF
--- a/writehat/static/css/component/TableOfFigures.css
+++ b/writehat/static/css/component/TableOfFigures.css
@@ -1,5 +1,15 @@
+.tof-item, .tof-pagenumber, .tof-dots, .tof-dots::before, .tof-pagenumber::after {
+  page-break-inside: avoid;
+  page-break-before: avoid;
+  page-break-after: avoid;
+}
+
 .tof-item {
   padding-right: 1ch;
+}
+
+.tof-list li {
+  list-style-type: none;
 }
 
 .tof-list a {

--- a/writehat/templates/componentTemplates/TableOfFigures.html
+++ b/writehat/templates/componentTemplates/TableOfFigures.html
@@ -3,8 +3,8 @@
   <div id="table-of-figures">
     <ul class="tof-list">
       {% for figure in report.figures %}
-        <a href='#figure_{{ figure.id }}'>
-          <li class="tof-entry">
+        <li>
+          <a class="tof-entry" href='#figure_{{ figure.id }}'>
             <span class="tof-item">
                 <span class="tof-header">
                     Figure <span class="tof-counter" target-component='#figure_{{ figure.id }}'></span>. 
@@ -13,8 +13,8 @@
             </span>
             <span class="tof-dots"></span>
             <span class="toc-pagenumber" target-component='#figure_{{ figure.id }}'></span>
-          </li>
-        </a>
+          </a>
+        </li>
       {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
 * Reverse order of li and anchor tags in Table of Figures component to fix errant page break at when ToF extends beyond one page
 * Apply `page-break-inside`, `page-break-before`, and `page-break-after` properties to all elements inside ToF list items