### PR TITLE
Add Active Directory Group Membership Filter

### DIFF
--- a/writehat/config/writehat.conf
+++ b/writehat/config/writehat.conf
@@ -40,6 +40,10 @@ domain = 'corp.local'
 tls = true
 # The LDAP search base for looking up users
 base = 'dc=corp,dc=local'
+# The LDAP group members filter for users
+# Example: 'cn=GroupA,ou=CorpUsers,dc=corp,dc=local
+# Leave blank for no filter
+filter = ''
 # The LDAP username and password for querying the LDAP database
 username = ''
 password = ''

--- a/writehat/lib/auth.py
+++ b/writehat/lib/auth.py
@@ -1,0 +1,15 @@
+from django_python3_ldap.utils import format_search_filters
+
+from writehat.lib.startup import *
+
+def custom_format_search_filters(ldap_fields):
+    # Check for ldap config
+    ldap_config = writehat_config.get('ldap', None)
+    if ldap_config is not None:
+        ldap_filter = ldap_config.get('filter', None)
+        # Apply filter is value is present
+        if ldap_filter is not None and ldap_filter:
+            ldap_fields["memberOf"] = ldap_filter
+    # Call the base format callable.
+    search_filters = format_search_filters(ldap_fields)
+    return search_filters

--- a/writehat/settings.py
+++ b/writehat/settings.py
@@ -73,7 +73,7 @@ LDAP_AUTH_SYNC_USER_RELATIONS = "django_python3_ldap.utils.sync_user_relations"
 # Path to a callable that takes a dict of {ldap_field_name: value},
 # returning a list of [ldap_search_filter]. The search filters will then be AND'd
 # together when creating the final search filter.
-LDAP_AUTH_FORMAT_SEARCH_FILTERS = "django_python3_ldap.utils.format_search_filters"
+LDAP_AUTH_FORMAT_SEARCH_FILTERS = "writehat.lib.auth.custom_format_search_filters"
 
 # Path to a callable that takes a dict of {model_field_name: value}, and returns
 # a string of the username to bind to the LDAP server.


### PR DESCRIPTION
# Summary

This PR adds the ability for WriteHat to filter authenticated users to a group membership.

Currently, WriteHat can only filter based on a base scope, e.g., `ou=OrgUnit,dc=corp,dc=local`. Anyone within the OU `OrgUnit` would be able to authenticate into the WriteHat instance.

This PR would allow to filter authorized users to a group membership within the OU, e.g. `CN=SomeGroupName,OU=OrgUnit,dc=corp,dc=local`

# Details

```bash
git diff --name-status github-dev
M       writehat/config/writehat.conf # Added functionality to include the filter option, with examples
A       writehat/lib/auth.py # Added filter search based on Active Directory using the ldap module for Django
M       writehat/settings.py # Directed the ldap module for Django to use the auth.py module for search filtering criteria
```
