### PR TITLE
Added activating/deactivating reports

### DIFF
--- a/writehat/lib/report.py
+++ b/writehat/lib/report.py
@@ -30,7 +30,7 @@ class BaseReport(WriteHatBaseModel):
     # JSON-serialized dictionary of component UUIDs
     _components = models.TextField(blank=True, default=str, validators=[isValidComponentJSON])
     pageTemplateID = models.UUIDField(null=True, blank=True)
-    isActive = models.BooleanField(default=bool)
+    isActive = models.BooleanField(default=True)
 
     @classmethod
     def new(cls, name, components=None, engagementParent=None, isActive=True):

--- a/writehat/lib/report.py
+++ b/writehat/lib/report.py
@@ -832,7 +832,7 @@ class reportForm(forms.Form):
 
     status = forms.ChoiceField(
         label='Report Status',
-        widget=forms.RadioSelect,
+        widget=forms.Select,
         choices=[
             ('inactive', 'Inactive'),
             ('active', 'Active'),

--- a/writehat/lib/report.py
+++ b/writehat/lib/report.py
@@ -30,15 +30,17 @@ class BaseReport(WriteHatBaseModel):
     # JSON-serialized dictionary of component UUIDs
     _components = models.TextField(blank=True, default=str, validators=[isValidComponentJSON])
     pageTemplateID = models.UUIDField(null=True, blank=True)
+    isActive = models.BooleanField(default=bool)
 
     @classmethod
-    def new(cls, name, components=None, engagementParent=None):
+    def new(cls, name, components=None, engagementParent=None, isActive=True):
         log.debug(f"{type(cls).__name__}.new()")
 
         log.debug(f"components: {components}")
 
         reportModel = cls(name=name)
         reportModel.engagementParent = engagementParent
+        reportModel.isActive = isActive
         #reportModel.save()
 
         if components is not None:
@@ -212,13 +214,17 @@ class BaseReport(WriteHatBaseModel):
         return tmpComponents
 
 
-    def update(self, componentJSON=None, name=None, pageTemplate=None):
+    def update(self, componentJSON=None, name=None, pageTemplate=None, isActive=None):
         log.debug("Report.update() called")
 
         # handle name
         if name is not None:
             log.debug(f"Setting report.name to {name}")
             self.name = name
+
+        if isActive is not None:
+            log.debug(f"Setting report.isActive to {isActive}")
+            self.isActive = isActive
 
         self.pageTemplateID = pageTemplate
 
@@ -712,12 +718,12 @@ class Report(BaseReport):
 
 
 
-    def update(self, componentJSON=None, reportName=None, pageTemplate=None, findings=None):
+    def update(self, componentJSON=None, reportName=None, pageTemplate=None, findings=None, isActive=None):
         '''
         Do everything that the parent function does, and also update findings
         '''
 
-        super().update(componentJSON, reportName, pageTemplate)
+        super().update(componentJSON, reportName, pageTemplate, isActive)
         if findings is not None:
             log.debug(f'Updating report findings: {findings}')
             validated_finding_uuids = list(self.validate_finding_uuids(findings))
@@ -824,5 +830,9 @@ class reportForm(forms.Form):
         widget=PageTemplateSelect()
     )
 
+    isActive = forms.BooleanField(
+        label='Is report active?',
+        initial=True
+    )
 
 BaseReport.formClass = reportForm

--- a/writehat/lib/report.py
+++ b/writehat/lib/report.py
@@ -30,7 +30,8 @@ class BaseReport(WriteHatBaseModel):
     # JSON-serialized dictionary of component UUIDs
     _components = models.TextField(blank=True, default=str, validators=[isValidComponentJSON])
     pageTemplateID = models.UUIDField(null=True, blank=True)
-    status = models.TextField(default='active')
+    status = models.TextField(default='active',
+                              choices=[("active", "Active"), ("inactive", "Inactive"), ("draft", "Draft")] )
 
     @classmethod
     def new(cls, name, components=None, engagementParent=None, status='active'):

--- a/writehat/lib/report.py
+++ b/writehat/lib/report.py
@@ -30,17 +30,17 @@ class BaseReport(WriteHatBaseModel):
     # JSON-serialized dictionary of component UUIDs
     _components = models.TextField(blank=True, default=str, validators=[isValidComponentJSON])
     pageTemplateID = models.UUIDField(null=True, blank=True)
-    isActive = models.BooleanField(default=True)
+    status = models.TextField(default='active')
 
     @classmethod
-    def new(cls, name, components=None, engagementParent=None, isActive=True):
+    def new(cls, name, components=None, engagementParent=None, status='active'):
         log.debug(f"{type(cls).__name__}.new()")
 
         log.debug(f"components: {components}")
 
         reportModel = cls(name=name)
         reportModel.engagementParent = engagementParent
-        reportModel.isActive = isActive
+        reportModel.status = status
         #reportModel.save()
 
         if components is not None:
@@ -214,7 +214,7 @@ class BaseReport(WriteHatBaseModel):
         return tmpComponents
 
 
-    def update(self, componentJSON=None, name=None, pageTemplate=None, isActive=None):
+    def update(self, componentJSON=None, name=None, pageTemplate=None, status=None):
         log.debug("Report.update() called")
 
         # handle name
@@ -222,9 +222,9 @@ class BaseReport(WriteHatBaseModel):
             log.debug(f"Setting report.name to {name}")
             self.name = name
 
-        if isActive is not None:
-            log.debug(f"Setting report.isActive to {isActive}")
-            self.isActive = isActive
+        if status is not None:
+            log.debug(f"Setting report.status to {status}")
+            self.status = status
 
         self.pageTemplateID = pageTemplate
 
@@ -718,12 +718,12 @@ class Report(BaseReport):
 
 
 
-    def update(self, componentJSON=None, reportName=None, pageTemplate=None, findings=None, isActive=None):
+    def update(self, componentJSON=None, reportName=None, pageTemplate=None, findings=None, status=None):
         '''
         Do everything that the parent function does, and also update findings
         '''
 
-        super().update(componentJSON, reportName, pageTemplate, isActive)
+        super().update(componentJSON, reportName, pageTemplate, status)
         if findings is not None:
             log.debug(f'Updating report findings: {findings}')
             validated_finding_uuids = list(self.validate_finding_uuids(findings))
@@ -830,9 +830,15 @@ class reportForm(forms.Form):
         widget=PageTemplateSelect()
     )
 
-    isActive = forms.BooleanField(
-        label='Is report active?',
-        initial=True
+    status = forms.ChoiceField(
+        label='Report Status',
+        widget=forms.RadioSelect,
+        choices=[
+            ('inactive', 'Inactive'),
+            ('active', 'Active'),
+            ('draft', 'Draft')
+        ],
+        initial='active'
     )
 
 BaseReport.formClass = reportForm

--- a/writehat/lib/report.py
+++ b/writehat/lib/report.py
@@ -26,12 +26,19 @@ class BaseReport(WriteHatBaseModel):
 
     class Meta:
         abstract = True
+
+    
+    statusChoices = [
+        ("active", "Active"), 
+        ("inactive", "Inactive"), 
+        ("draft", "Draft")
+    ]
     
     # JSON-serialized dictionary of component UUIDs
     _components = models.TextField(blank=True, default=str, validators=[isValidComponentJSON])
     pageTemplateID = models.UUIDField(null=True, blank=True)
     status = models.TextField(default='active',
-                              choices=[("active", "Active"), ("inactive", "Inactive"), ("draft", "Draft")] )
+                              choices=statusChoices )
 
     @classmethod
     def new(cls, name, components=None, engagementParent=None, status='active'):
@@ -834,11 +841,7 @@ class reportForm(forms.Form):
     status = forms.ChoiceField(
         label='Report Status',
         widget=forms.Select,
-        choices=[
-            ('inactive', 'Inactive'),
-            ('active', 'Active'),
-            ('draft', 'Draft')
-        ],
+        choices=BaseReport.statusChoices,
         initial='active'
     )
 

--- a/writehat/models.py
+++ b/writehat/models.py
@@ -199,7 +199,7 @@ class WriteHatBaseModel(models.Model):
             if label in validFormFields:
                 initialFormData.update({label: value})
                 log.debug(f'   Successfully copied: {label}')
-            #else:
+            # else:
             #    log.debug(f'   Did not copy: {label}')
 
         #log.debug(f'initialFormData: {initialFormData}')

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -34,6 +34,33 @@ $(document).ready(function() {
 
   });
 
+  // Toggle filtering by active reports
+  function filterRowsByActive(isActive) {
+    $('.report-row').each(function() {
+      if (isActive) {
+        if (!$(this).data('isActive')) {
+          $(this).hide();
+        } else {
+          $(this).show();
+        }
+      } else {
+        $(this).show();
+      }
+    });
+  }
+
+  // Toggle filtering by active reports
+  var isActiveToggle = $('#isActiveToggle');
+  
+  isActiveToggle.change(function() {
+    var isActive = $(this).prop('checked');
+    filterRowsByActive(isActive);
+  });
+    
+  // Call the filterRowsByActive function on page load
+  var isActiveInitially = isActiveToggle.prop('checked');
+  filterRowsByActive(isActiveInitially);
+
 
   // edit button
   $('#engagementEdit').click(function(e) {

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -34,32 +34,31 @@ $(document).ready(function() {
 
   });
 
-  // Toggle filtering by active reports
-  function filterRowsByActive(isActive) {
-    $('.report-row').each(function() {
-      if (isActive) {
-        if (!$(this).data('isActive')) {
-          $(this).hide();
-        } else {
-          $(this).show();
-        }
-      } else {
-        $(this).show();
-      }
-    });
-  }
+  // Table Filtering
 
-  // Toggle filtering by active reports
-  var isActiveToggle = $('#isActiveToggle');
+  var actvToggle = $('#filterActiveToggle');
+
+  // Custom range filtering function
+  $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+      var isActv = actvToggle.prop('checked');
+      var itemActive = data[4]; // use data for the active status column
   
-  isActiveToggle.change(function() {
-    var isActive = $(this).prop('checked');
-    filterRowsByActive(isActive);
+      if (isActv) {
+          return itemActive == "True";
+      } else {
+          return true;
+      }
   });
-    
-  // Call the filterRowsByActive function on page load
-  var isActiveInitially = isActiveToggle.prop('checked');
-  filterRowsByActive(isActiveInitially);
+  
+  var table = $('#reports').DataTable();
+  
+  // Bind the change event handler
+  actvToggle.change(function() {
+      table.draw();
+  });
+  
+  // Trigger the change event to set the filter active by default
+  actvToggle.trigger('change');
 
   // edit button
   $('#engagementEdit').click(function(e) {

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -8,8 +8,29 @@ function updateFindingPrefix() {
   $('.modal').find('input[name="prefix"]').val(prefixes[scoringType]);
 }
 
+function saveState() {
+  console.log("SAVED");
+  var status = {};
+  $(".btn-save-state").each(function() {
+    status[$(this).attr("id")] = $(this).prop("checked");
+  });
+  localStorage.setItem("status", JSON.stringify(status));
+}
 
 $(document).ready(function() {
+
+  if (localStorage.getItem("status")) {
+    var savedStatus = JSON.parse(localStorage.getItem("status"));
+    if (savedStatus) {
+      $(".btn-save-state").each(function() {
+        var id = $(this).attr("id");
+        if (savedStatus.hasOwnProperty(id)) {
+          $(this).prop("checked", savedStatus[id]);
+          $(this).closest("label").toggleClass("active", savedStatus[id]);
+        }
+      });
+    }
+  }
 
   var engagementID = $('#engagement-info').attr('engagement-id');
   var engagementName = $('#engagement-info').attr('engagement-name');
@@ -34,27 +55,17 @@ $(document).ready(function() {
 
   });
 
-  // Table Filtering
-  var status = $('input[name="status"]:checked');
-
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    var statusValue = new Array();
-    $.each($("input[name='status']:checked"), function() {
-      statusValue.push($(this).val());
-    });
-
-    var itemActive = data[4]; // use data for the active status column
-
-    if (statusValue.includes(itemActive)) { return true; }
-
-    return false;
+    var itemStatus = data[4];
+    return $(`input[name='status'][value='${itemStatus}']:checked`).length === 1;
   });
-  
+
   var table = $('#reports').DataTable();
   
   // Bind the change event handler
   $('#status-radio').change(function() {
+      saveState();
       table.draw();
   });
   

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -35,30 +35,36 @@ $(document).ready(function() {
   });
 
   // Table Filtering
-
-  var actvToggle = $('#filterActiveToggle');
+  var status = $('input[name="status"]:checked');
+  console.log("status:" + status);
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-      var isActv = actvToggle.prop('checked');
-      var itemActive = data[4]; // use data for the active status column
-  
-      if (isActv) {
-          return itemActive == "True";
-      } else {
-          return true;
-      }
+    statusValue = $("input[name='status']:checked").val();
+    console.log("status value: " + statusValue);
+    var itemActive = data[4]; // use data for the active status column
+
+    if (statusValue == "inactive") {
+      return itemActive == "inactive";
+    } else if (statusValue == "active") {
+      return itemActive == "active";
+    } else if ( statusValue == "draft") {
+      return itemActive == "draft";
+    }
+
+    return true;
   });
   
   var table = $('#reports').DataTable();
   
   // Bind the change event handler
-  actvToggle.change(function() {
+  $('#status-radio').change(function() {
       table.draw();
+      console.log("status change detevted.")
   });
   
   // Trigger the change event to set the filter active by default
-  actvToggle.trigger('change');
+  $('#status-radio').trigger('change');
 
   // edit button
   $('#engagementEdit').click(function(e) {

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -36,23 +36,19 @@ $(document).ready(function() {
 
   // Table Filtering
   var status = $('input[name="status"]:checked');
-  console.log("status:" + status);
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    statusValue = $("input[name='status']:checked").val();
-    console.log("status value: " + statusValue);
+    var statusValue = new Array();
+    $.each($("input[name='status']:checked"), function() {
+      statusValue.push($(this).val());
+    });
+
     var itemActive = data[4]; // use data for the active status column
 
-    if (statusValue == "inactive") {
-      return itemActive == "inactive";
-    } else if (statusValue == "active") {
-      return itemActive == "active";
-    } else if ( statusValue == "draft") {
-      return itemActive == "draft";
-    }
+    if (statusValue.includes(itemActive)) { return true; }
 
-    return true;
+    return false;
   });
   
   var table = $('#reports').DataTable();
@@ -60,7 +56,6 @@ $(document).ready(function() {
   // Bind the change event handler
   $('#status-radio').change(function() {
       table.draw();
-      console.log("status change detevted.")
   });
   
   // Trigger the change event to set the filter active by default

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -61,7 +61,6 @@ $(document).ready(function() {
   var isActiveInitially = isActiveToggle.prop('checked');
   filterRowsByActive(isActiveInitially);
 
-
   // edit button
   $('#engagementEdit').click(function(e) {
     loadModal('engagementEdit', function(engagementEditModal) {

--- a/writehat/static/js/savedReports.js
+++ b/writehat/static/js/savedReports.js
@@ -2,23 +2,19 @@ $(document).ready(function() {
 
   // Table Filtering
   var status = $('input[name="status"]:checked');
-  console.log("status:" + status);
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    statusValue = $("input[name='status']:checked").val();
-    console.log("status value: " + statusValue);
+    var statusValue = new Array();
+    $.each($("input[name='status']:checked"), function() {
+      statusValue.push($(this).val());
+    });
+
     var itemActive = data[4]; // use data for the active status column
 
-    if (statusValue == "inactive") {
-      return itemActive == "inactive";
-    } else if (statusValue == "active") {
-      return itemActive == "active";
-    } else if ( statusValue == "draft") {
-      return itemActive == "draft";
-    }
+    if (statusValue.includes(itemActive)) { return true; }
 
-    return true;
+    return false;
   });
   
   var table = $('#reports').DataTable();
@@ -26,10 +22,9 @@ $(document).ready(function() {
   // Bind the change event handler
   $('#status-radio').change(function() {
       table.draw();
-      console.log("status change detevted.")
   });
   
   // Trigger the change event to set the filter active by default
   $('#status-radio').trigger('change');
 
-})
+});

--- a/writehat/static/js/savedReports.js
+++ b/writehat/static/js/savedReports.js
@@ -1,30 +1,28 @@
 $(document).ready(function() {
 
-  // Toggle filtering by active reports
-  function filterRowsByActive(isActive) {
-    $('.report-row').each(function() {
-      if (isActive) {
-        if (!$(this).data('isActive')) {
-          $(this).hide();
-        } else {
-          $(this).show();
-        }
-      } else {
-        $(this).show();
-      }
-    });
-  }
+  // Table Filtering
+  var actvToggle = $('#filterActiveToggle');
 
-  // Toggle filtering by active reports
-  var isActiveToggle = $('#isActiveToggle');
+  // Custom range filtering function
+  $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+      var isActv = actvToggle.prop('checked');
+      var itemActive = data[4]; // use data for the active status column
   
-  isActiveToggle.change(function() {
-    var isActive = $(this).prop('checked');
-    filterRowsByActive(isActive);
+      if (isActv) {
+          return itemActive == "True";
+      } else {
+          return true;
+      }
   });
-    
-  // Call the filterRowsByActive function on page load
-  var isActiveInitially = isActiveToggle.prop('checked');
-  filterRowsByActive(isActiveInitially);
+  
+  var table = $('#reports').DataTable();
+  
+  // Bind the change event handler
+  actvToggle.change(function() {
+      table.draw();
+  });
+  
+  // Trigger the change event to set the filter active by default
+  actvToggle.trigger('change');
 
 })

--- a/writehat/static/js/savedReports.js
+++ b/writehat/static/js/savedReports.js
@@ -1,28 +1,35 @@
 $(document).ready(function() {
 
   // Table Filtering
-  var actvToggle = $('#filterActiveToggle');
+  var status = $('input[name="status"]:checked');
+  console.log("status:" + status);
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-      var isActv = actvToggle.prop('checked');
-      var itemActive = data[4]; // use data for the active status column
-  
-      if (isActv) {
-          return itemActive == "True";
-      } else {
-          return true;
-      }
+    statusValue = $("input[name='status']:checked").val();
+    console.log("status value: " + statusValue);
+    var itemActive = data[4]; // use data for the active status column
+
+    if (statusValue == "inactive") {
+      return itemActive == "inactive";
+    } else if (statusValue == "active") {
+      return itemActive == "active";
+    } else if ( statusValue == "draft") {
+      return itemActive == "draft";
+    }
+
+    return true;
   });
   
   var table = $('#reports').DataTable();
   
   // Bind the change event handler
-  actvToggle.change(function() {
+  $('#status-radio').change(function() {
       table.draw();
+      console.log("status change detevted.")
   });
   
   // Trigger the change event to set the filter active by default
-  actvToggle.trigger('change');
+  $('#status-radio').trigger('change');
 
 })

--- a/writehat/static/js/savedReports.js
+++ b/writehat/static/js/savedReports.js
@@ -1,26 +1,38 @@
+function saveState() {
+  console.log("SAVED");
+  var status = {};
+  $(".btn-save-state").each(function() {
+    status[$(this).attr("id")] = $(this).prop("checked");
+  });
+  localStorage.setItem("status", JSON.stringify(status));
+}
+
 $(document).ready(function() {
 
-  // Table Filtering
-  var status = $('input[name="status"]:checked');
+  if (localStorage.getItem("status")) {
+    var savedStatus = JSON.parse(localStorage.getItem("status"));
+    if (savedStatus) {
+      $(".btn-save-state").each(function() {
+        var id = $(this).attr("id");
+        if (savedStatus.hasOwnProperty(id)) {
+          $(this).prop("checked", savedStatus[id]);
+          $(this).closest("label").toggleClass("active", savedStatus[id]);
+        }
+      });
+    }
+  }
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    var statusValue = new Array();
-    $.each($("input[name='status']:checked"), function() {
-      statusValue.push($(this).val());
-    });
-
-    var itemActive = data[4]; // use data for the active status column
-
-    if (statusValue.includes(itemActive)) { return true; }
-
-    return false;
+    var itemStatus = data[4];
+    return $(`input[name='status'][value='${itemStatus}']:checked`).length === 1;
   });
   
   var table = $('#reports').DataTable();
   
   // Bind the change event handler
   $('#status-radio').change(function() {
+    saveState();
       table.draw();
   });
   

--- a/writehat/static/js/savedReports.js
+++ b/writehat/static/js/savedReports.js
@@ -1,0 +1,30 @@
+$(document).ready(function() {
+
+  // Toggle filtering by active reports
+  function filterRowsByActive(isActive) {
+    $('.report-row').each(function() {
+      if (isActive) {
+        if (!$(this).data('isActive')) {
+          $(this).hide();
+        } else {
+          $(this).show();
+        }
+      } else {
+        $(this).show();
+      }
+    });
+  }
+
+  // Toggle filtering by active reports
+  var isActiveToggle = $('#isActiveToggle');
+  
+  isActiveToggle.change(function() {
+    var isActive = $(this).prop('checked');
+    filterRowsByActive(isActive);
+  });
+    
+  // Call the filterRowsByActive function on page load
+  var isActiveInitially = isActiveToggle.prop('checked');
+  filterRowsByActive(isActiveInitially);
+
+})

--- a/writehat/templates/pages/savedReports.html
+++ b/writehat/templates/pages/savedReports.html
@@ -17,5 +17,6 @@
 
 {% endblock %}
 {% block footer %}
+  <script src="/static/js/savedReports.js"></script>
   <script src="/static/js/reports.js"></script>
 {% endblock %}

--- a/writehat/templates/panes/engagementReportsList.html
+++ b/writehat/templates/panes/engagementReportsList.html
@@ -5,31 +5,32 @@
     </div>
     <div class='ml-auto'>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="isActiveToggle" checked="checked">
+        <input class="form-check-input" type="checkbox" id="filterActiveToggle" checked>
         <label class="form-check-label" for="isActiveToggle">Filter by Active</label>
       </div>
       {% include 'snippets/textButton.html' with name='New Report' id='reportCreate' type='plus' class='btn-primary' %}
     </div>
   </div>
-
-  <table class="writehat-table container-fluid table-light table-striped table-hover overflow-auto paginate writehat-reports">
+  <table class="writehat-table container-fluid table-light table-striped table-hover overflow-auto paginate writehat-reports" id="reports">
     <thead>
+      <th></th>
       <tr>
         <th><strong>Name</strong></th>
         <th><strong>Components</strong></th>
         <th><strong>Created</strong></th>
         <th><strong>Modified</strong></th>
+        <th><strong>Active</strong></th>
         <th></th>
       </tr>
     </thead>
     <tbody class="text-nowrap">
-
       {% for report in engagement.reports|dictsortreversed:"modifiedDate" %}
-          <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}" {% if not report.isActive %}data-is-active="false"{% else %}data-is-active="true"{% endif %}>
+          <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}">
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.name }}</a></td>
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
+            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.isActive }}</a></td>
             <td>
               <div class="floating float-right vertical-align-center mt-1">
                 {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}

--- a/writehat/templates/panes/engagementReportsList.html
+++ b/writehat/templates/panes/engagementReportsList.html
@@ -4,6 +4,10 @@
       <h4>Reports: {{ engagement.reports|length }}</h4>
     </div>
     <div class='ml-auto'>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="isActiveToggle" checked="checked">
+        <label class="form-check-label" for="isActiveToggle">Filter by Active</label>
+      </div>
       {% include 'snippets/textButton.html' with name='New Report' id='reportCreate' type='plus' class='btn-primary' %}
     </div>
   </div>
@@ -19,22 +23,23 @@
       </tr>
     </thead>
     <tbody class="text-nowrap">
+
       {% for report in engagement.reports|dictsortreversed:"modifiedDate" %}
-        <tr report-id="{{ report.id }}" report-name="{{ report.name }}">
-          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.name }}</a></td>
-          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
-          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
-          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
-          <td>
-            <div class="floating float-right vertical-align-center mt-1">
-              {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}
-              {% include 'snippets/smallButton.html' with title='Generate HTML' type='file-code' class='reportGenerateHTML engagement-reports text-white' attrs='style="border: 2px solid var(--warning)"' %}
-              {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}
-              {% include 'snippets/smallButton.html' with title='Edit Report' type='pen' class='reportEdit text-dark' %}
-              {% include 'snippets/smallButton.html' with title='Delete Report' type='times-circle' class='reportDelete text-danger' %}
-            </div>
-          </td>
-        </tr>
+          <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}" {% if not report.isActive %}data-is-active="false"{% else %}data-is-active="true"{% endif %}>
+            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.name }}</a></td>
+            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
+            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
+            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
+            <td>
+              <div class="floating float-right vertical-align-center mt-1">
+                {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}
+                {% include 'snippets/smallButton.html' with title='Generate HTML' type='file-code' class='reportGenerateHTML engagement-reports text-white' attrs='style="border: 2px solid var(--warning)"' %}
+                {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}
+                {% include 'snippets/smallButton.html' with title='Edit Report' type='pen' class='reportEdit text-dark' %}
+                {% include 'snippets/smallButton.html' with title='Delete Report' type='times-circle' class='reportDelete text-danger' %}
+              </div>
+            </td>
+          </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/writehat/templates/panes/engagementReportsList.html
+++ b/writehat/templates/panes/engagementReportsList.html
@@ -27,7 +27,7 @@
           <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
           <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
           <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
-          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.status }}</a></td>
+          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.status|title }}</a></td>
           <td>
             <div class="floating float-right vertical-align-center mt-1">
               {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}

--- a/writehat/templates/panes/engagementReportsList.html
+++ b/writehat/templates/panes/engagementReportsList.html
@@ -5,8 +5,15 @@
     </div>
     <div class='ml-auto'>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="filterActiveToggle" checked>
-        <label class="form-check-label" for="isActiveToggle">Filter by Active</label>
+        <form id="status-radio">
+          <label class="form-check-label" for="isActiveToggle">Filter by Status</label>
+          <input type="radio" id="inactive" name="status" value="inactive">
+          <label for="inactive">Inactive</label><br>
+          <input type="radio" id="active" name="status" value="active">
+          <label for="active">Active</label><br>
+          <input type="radio" id="draft" name="status" value="draft">
+          <label for="draft">Draft</label>
+        </form>
       </div>
       {% include 'snippets/textButton.html' with name='New Report' id='reportCreate' type='plus' class='btn-primary' %}
     </div>
@@ -19,7 +26,7 @@
         <th><strong>Components</strong></th>
         <th><strong>Created</strong></th>
         <th><strong>Modified</strong></th>
-        <th><strong>Active</strong></th>
+        <th><strong>Status</strong></th>
         <th></th>
       </tr>
     </thead>
@@ -30,7 +37,7 @@
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
             <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
-            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.isActive }}</a></td>
+            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.status }}</a></td>
             <td>
               <div class="floating float-right vertical-align-center mt-1">
                 {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}

--- a/writehat/templates/panes/engagementReportsList.html
+++ b/writehat/templates/panes/engagementReportsList.html
@@ -4,17 +4,7 @@
       <h4>Reports: {{ engagement.reports|length }}</h4>
     </div>
     <div class='ml-auto'>
-      <div class="form-check">
-        <form id="status-radio">
-          <label class="form-check-label" for="isActiveToggle">Filter by Status</label>
-          <input type="radio" id="inactive" name="status" value="inactive">
-          <label for="inactive">Inactive</label><br>
-          <input type="radio" id="active" name="status" value="active">
-          <label for="active">Active</label><br>
-          <input type="radio" id="draft" name="status" value="draft">
-          <label for="draft">Draft</label>
-        </form>
-      </div>
+      {% include 'snippets/statusButtonGroup.html' %}
       {% include 'snippets/textButton.html' with name='New Report' id='reportCreate' type='plus' class='btn-primary' %}
     </div>
   </div>
@@ -32,22 +22,22 @@
     </thead>
     <tbody class="text-nowrap">
       {% for report in engagement.reports|dictsortreversed:"modifiedDate" %}
-          <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}">
-            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.name }}</a></td>
-            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
-            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
-            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
-            <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.status }}</a></td>
-            <td>
-              <div class="floating float-right vertical-align-center mt-1">
-                {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}
-                {% include 'snippets/smallButton.html' with title='Generate HTML' type='file-code' class='reportGenerateHTML engagement-reports text-white' attrs='style="border: 2px solid var(--warning)"' %}
-                {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}
-                {% include 'snippets/smallButton.html' with title='Edit Report' type='pen' class='reportEdit text-dark' %}
-                {% include 'snippets/smallButton.html' with title='Delete Report' type='times-circle' class='reportDelete text-danger' %}
-              </div>
-            </td>
-          </tr>
+        <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}">
+          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.name }}</a></td>
+          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.numComponents }}</a></td>
+          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.createdDate }}</a></td>
+          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.modifiedDate }}</a></td>
+          <td><a href="/engagements/report/{{ report.id }}/edit">{{ report.status }}</a></td>
+          <td>
+            <div class="floating float-right vertical-align-center mt-1">
+              {% include 'snippets/smallButton.html' with title='Generate PDF' type='file-pdf' class='reportGeneratePDF engagement-reports text-white' attrs='style="border: 2px solid var(--danger)"' %}
+              {% include 'snippets/smallButton.html' with title='Generate HTML' type='file-code' class='reportGenerateHTML engagement-reports text-white' attrs='style="border: 2px solid var(--warning)"' %}
+              {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}
+              {% include 'snippets/smallButton.html' with title='Edit Report' type='pen' class='reportEdit text-dark' %}
+              {% include 'snippets/smallButton.html' with title='Delete Report' type='times-circle' class='reportDelete text-danger' %}
+            </div>
+          </td>
+        </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/writehat/templates/panes/reportsList.html
+++ b/writehat/templates/panes/reportsList.html
@@ -4,6 +4,10 @@
       <h5>Report Templates</h5>
     </div>
     <div class='ml-auto'>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="isActiveToggle" checked="checked">
+        <label class="form-check-label" for="isActiveToggle">Filter by Active</label>
+      </div>
       {% include 'snippets/textButton.html' with href='/templates/new' name='New Report Template' type='plus' class='btn-primary' %}
     </div>
   </div>
@@ -19,7 +23,7 @@
     </thead>
     <tbody class="text-nowrap">
       {% for report in reports|dictsortreversed:"modifiedDate" %}
-        <tr report-id="{{ report.id }}" report-name="{{ report.name }}">
+        <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}" {% if not report.isActive %}data-is-active="false"{% else %}data-is-active="true"{% endif %}>
           <td class="pl-2 reportEdit" style="cursor:pointer">{{ report.name }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.numComponents }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.createdDate }}</td>

--- a/writehat/templates/panes/reportsList.html
+++ b/writehat/templates/panes/reportsList.html
@@ -3,10 +3,16 @@
     <div>
       <h5>Report Templates</h5>
     </div>
-    <div class='ml-auto'>
+    <div class='auto-ml'>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="filterActiveToggle" checked>
-        <label class="form-check-label" for="isActiveToggle">Filter by Active</label>
+        <form id="status-radio">
+          <input type="radio" id="inactive" name="status" value="inactive">
+          <label for="inactive">Inactive</label><br>
+          <input type="radio" id="active" name="status" value="active">
+          <label for="active">Active</label><br>
+          <input type="radio" id="draft" name="status" value="draft">
+          <label for="draft">Draft</label>
+        </form>
       </div>
       {% include 'snippets/textButton.html' with href='/templates/new' name='New Report Template' type='plus' class='btn-primary' %}
     </div>
@@ -19,7 +25,7 @@
         <th><strong>Components</strong></th>
         <th><strong>Created</strong></th>
         <th><strong>Modified</strong></th>
-        <th><strong>Active</strong></th>
+        <th><strong>Status</strong></th>
         <th>
       </tr>
     </thead>
@@ -30,7 +36,7 @@
           <td class="reportEdit" style="cursor:pointer">{{ report.numComponents }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.createdDate }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.modifiedDate }}</td>
-          <td class="reportEdit" style="cursor:pointer">{{ report.isActive }}</td>
+          <td class="reportEdit" style="cursor:pointer">{{ report.status }}</td>
           <td>
             <div class="floating float-right mt-1">
               {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}

--- a/writehat/templates/panes/reportsList.html
+++ b/writehat/templates/panes/reportsList.html
@@ -3,17 +3,8 @@
     <div>
       <h5>Report Templates</h5>
     </div>
-    <div class='auto-ml'>
-      <div class="form-check">
-        <form id="status-radio">
-          <input type="radio" id="inactive" name="status" value="inactive">
-          <label for="inactive">Inactive</label><br>
-          <input type="radio" id="active" name="status" value="active">
-          <label for="active">Active</label><br>
-          <input type="radio" id="draft" name="status" value="draft">
-          <label for="draft">Draft</label>
-        </form>
-      </div>
+    <div class='ml-auto'>
+      {% include 'snippets/statusButtonGroup.html' %}
       {% include 'snippets/textButton.html' with href='/templates/new' name='New Report Template' type='plus' class='btn-primary' %}
     </div>
   </div>

--- a/writehat/templates/panes/reportsList.html
+++ b/writehat/templates/panes/reportsList.html
@@ -27,7 +27,7 @@
           <td class="reportEdit" style="cursor:pointer">{{ report.numComponents }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.createdDate }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.modifiedDate }}</td>
-          <td class="reportEdit" style="cursor:pointer">{{ report.status }}</td>
+          <td class="reportEdit" style="cursor:pointer">{{ report.status|title }}</td>
           <td>
             <div class="floating float-right mt-1">
               {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}

--- a/writehat/templates/panes/reportsList.html
+++ b/writehat/templates/panes/reportsList.html
@@ -5,29 +5,32 @@
     </div>
     <div class='ml-auto'>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="isActiveToggle" checked="checked">
+        <input class="form-check-input" type="checkbox" id="filterActiveToggle" checked>
         <label class="form-check-label" for="isActiveToggle">Filter by Active</label>
       </div>
       {% include 'snippets/textButton.html' with href='/templates/new' name='New Report Template' type='plus' class='btn-primary' %}
     </div>
   </div>
-  <table class="container-fluid writehat-table table-light table-striped table-hover overflow-auto paginate writehat-reports">
+  <table class="container-fluid writehat-table table-light table-striped table-hover overflow-auto paginate writehat-reports" id="reports">
     <thead>
+      <th></th>
       <tr>
         <th><strong>Name</strong></th>
         <th><strong>Components</strong></th>
         <th><strong>Created</strong></th>
         <th><strong>Modified</strong></th>
-        <th></th>
+        <th><strong>Active</strong></th>
+        <th>
       </tr>
     </thead>
     <tbody class="text-nowrap">
       {% for report in reports|dictsortreversed:"modifiedDate" %}
-        <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}" {% if not report.isActive %}data-is-active="false"{% else %}data-is-active="true"{% endif %}>
+        <tr class="report-row" report-id="{{ report.id }}" report-name="{{ report.name }}">
           <td class="pl-2 reportEdit" style="cursor:pointer">{{ report.name }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.numComponents }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.createdDate }}</td>
           <td class="reportEdit" style="cursor:pointer">{{ report.modifiedDate }}</td>
+          <td class="reportEdit" style="cursor:pointer">{{ report.isActive }}</td>
           <td>
             <div class="floating float-right mt-1">
               {% include 'snippets/smallButton.html' with title='Clone Report' type='copy' class='reportClone text-white' %}

--- a/writehat/templates/snippets/statusButtonGroup.html
+++ b/writehat/templates/snippets/statusButtonGroup.html
@@ -1,0 +1,15 @@
+<div class="form-check form-check-inline">
+  <form id="status-radio">
+    <div class="btn-group btn-group-toggle" role="group" data-toggle="buttons">
+      <label for="inactive" class="btn btn-outline-primary">
+        <input type="checkbox" class="btn-check" id="inactive" name="status" value="inactive" autocomplete="off">Inactive
+      </label>
+      <label for="active" class="btn btn-outline-primary active">
+        <input type="checkbox" class="btn-check" id="active" name="status" value="active" checked autocomplete="off">Active
+      </label>
+      <label for="draft" class="btn btn-outline-primary">
+        <input type="checkbox" class="btn-check" id="draft" name="status" value="draft" autocomplete="off">Draft
+      </label>
+    </div>
+  </form>
+</div>

--- a/writehat/templates/snippets/statusButtonGroup.html
+++ b/writehat/templates/snippets/statusButtonGroup.html
@@ -1,14 +1,15 @@
+<span>Show only:</span>
 <div class="form-check form-check-inline">
-  <form id="status-radio">
+  <form id="status-radio" data-toggle="tooltip">
     <div class="btn-group btn-group-toggle" role="group" data-toggle="buttons">
       <label for="inactive" class="btn btn-outline-primary">
-        <input type="checkbox" class="btn-check" id="inactive" name="status" value="inactive" autocomplete="off">Inactive
+        <input type="checkbox" class="btn-check btn-save-state" id="inactive" name="status" value="Inactive" autocomplete="off">Inactive
       </label>
       <label for="active" class="btn btn-outline-primary active">
-        <input type="checkbox" class="btn-check" id="active" name="status" value="active" checked autocomplete="off">Active
+        <input type="checkbox" class="btn-check btn-save-state" id="active" name="status" value="Active" checked autocomplete="off">Active
       </label>
-      <label for="draft" class="btn btn-outline-primary">
-        <input type="checkbox" class="btn-check" id="draft" name="status" value="draft" autocomplete="off">Draft
+      <label for="draft" class="btn btn-outline-primary active">
+        <input type="checkbox" class="btn-check btn-save-state" id="draft" name="status" value="Draft" checked autocomplete="off">Draft
       </label>
     </div>
   </form>

--- a/writehat/views.py
+++ b/writehat/views.py
@@ -292,9 +292,9 @@ def reportCreate(request, uuid=None, fromTemplate=False):
 
     try:
         reportName = decodedJson['name']
-        activeStatus = True if decodedJson['isActive'] == "on" else False
         log.debug(f"reportName: {reportName}")
         reportComponents = decodedJson['reportComponents']
+        activeStatus = decodedJson.get('isActive') == 'on'
         # Everything is validated, lets instantiate the report
         report = None
         if uuid:
@@ -388,9 +388,7 @@ def reportUpdate(request,uuid,fromTemplate=False):
         reportName = reportJSON.get('name', None)
         reportPageTemplate = reportJSON.get('pageTemplateID', None)
         reportFindings = reportJSON.get('reportFindings', None)
-        reportActiveStatus = reportJSON.get('isActive', None)
-
-        reportActiveStatus = True if reportActiveStatus == "on" else False
+        reportActiveStatus = reportJSON.get('isActive') == 'on'
 
         if componentJSON is not None:
             log.debug("In reportUpdate()")

--- a/writehat/views.py
+++ b/writehat/views.py
@@ -292,20 +292,21 @@ def reportCreate(request, uuid=None, fromTemplate=False):
 
     try:
         reportName = decodedJson['name']
+        activeStatus = True if decodedJson['isActive'] == "on" else False
         log.debug(f"reportName: {reportName}")
         reportComponents = decodedJson['reportComponents']
         # Everything is validated, lets instantiate the report
         report = None
         if uuid:
             log.debug(f"saving report (with engagementParent) reportComponents: {reportComponents}")
-            report = Report.new(name=reportName, components=reportComponents,engagementParent=uuid)
+            report = Report.new(name=reportName, components=reportComponents, engagementParent=uuid, isActive=activeStatus)
         #    report.engagementParent = uuid
        #     report.save()
         else:
             if fromTemplate:
-                report = SavedReport.new(name=reportName, components=reportComponents)
+                report = SavedReport.new(name=reportName, components=reportComponents, isActive=activeStatus)
             else:
-                report = Report.new(name=reportName, components=reportComponents)
+                report = Report.new(name=reportName, components=reportComponents, isActive=activeStatus)
 
     except ReportValidationError:
         log.warn("reportCreate() threw ReportValidationError")
@@ -387,6 +388,9 @@ def reportUpdate(request,uuid,fromTemplate=False):
         reportName = reportJSON.get('name', None)
         reportPageTemplate = reportJSON.get('pageTemplateID', None)
         reportFindings = reportJSON.get('reportFindings', None)
+        reportActiveStatus = reportJSON.get('isActive', None)
+
+        reportActiveStatus = True if reportActiveStatus == "on" else False
 
         if componentJSON is not None:
             log.debug("In reportUpdate()")
@@ -398,12 +402,12 @@ def reportUpdate(request,uuid,fromTemplate=False):
         if fromTemplate:
             log.debug("fromTemplate is true:")
             report = SavedReport.get(id=uuid)
-            report.update(componentJSON, reportName, reportPageTemplate)
+            report.update(componentJSON, reportName, reportPageTemplate, isActive=reportActiveStatus)
         else:
             log.debug("fromTemplate is false:")
             # Update the report
             report = Report.get(id=uuid)
-            report.update(componentJSON, reportName, reportPageTemplate, reportFindings)
+            report.update(componentJSON, reportName, reportPageTemplate, reportFindings, isActive=reportActiveStatus)
 
 
     except ReportValidationError as e:

--- a/writehat/views.py
+++ b/writehat/views.py
@@ -294,19 +294,19 @@ def reportCreate(request, uuid=None, fromTemplate=False):
         reportName = decodedJson['name']
         log.debug(f"reportName: {reportName}")
         reportComponents = decodedJson['reportComponents']
-        activeStatus = decodedJson.get('isActive') == 'on'
+        status = decodedJson.get('status')
         # Everything is validated, lets instantiate the report
         report = None
         if uuid:
             log.debug(f"saving report (with engagementParent) reportComponents: {reportComponents}")
-            report = Report.new(name=reportName, components=reportComponents, engagementParent=uuid, isActive=activeStatus)
+            report = Report.new(name=reportName, components=reportComponents, engagementParent=uuid, status=status)
         #    report.engagementParent = uuid
        #     report.save()
         else:
             if fromTemplate:
-                report = SavedReport.new(name=reportName, components=reportComponents, isActive=activeStatus)
+                report = SavedReport.new(name=reportName, components=reportComponents, status=status)
             else:
-                report = Report.new(name=reportName, components=reportComponents, isActive=activeStatus)
+                report = Report.new(name=reportName, components=reportComponents, status=status)
 
     except ReportValidationError:
         log.warn("reportCreate() threw ReportValidationError")
@@ -388,7 +388,7 @@ def reportUpdate(request,uuid,fromTemplate=False):
         reportName = reportJSON.get('name', None)
         reportPageTemplate = reportJSON.get('pageTemplateID', None)
         reportFindings = reportJSON.get('reportFindings', None)
-        reportActiveStatus = reportJSON.get('isActive') == 'on'
+        reportStatus = reportJSON.get('status', None)
 
         if componentJSON is not None:
             log.debug("In reportUpdate()")
@@ -400,12 +400,12 @@ def reportUpdate(request,uuid,fromTemplate=False):
         if fromTemplate:
             log.debug("fromTemplate is true:")
             report = SavedReport.get(id=uuid)
-            report.update(componentJSON, reportName, reportPageTemplate, isActive=reportActiveStatus)
+            report.update(componentJSON, reportName, reportPageTemplate, status=reportStatus)
         else:
             log.debug("fromTemplate is false:")
             # Update the report
             report = Report.get(id=uuid)
-            report.update(componentJSON, reportName, reportPageTemplate, reportFindings, isActive=reportActiveStatus)
+            report.update(componentJSON, reportName, reportPageTemplate, reportFindings, status=reportStatus)
 
 
     except ReportValidationError as e:


### PR DESCRIPTION
- Added checkbox on report editor to choose if the specified report is active or not.
- Added checkbox on list of reports inside an engagement to choose whether or not you'd like to only view active reports.
   - All logic for toggling filter is done client-side, but a column was added in the database for whether each report is active or not.