### PR TITLE
Todo markers

### DIFF
--- a/writehat/components/FindingsList.py
+++ b/writehat/components/FindingsList.py
@@ -97,6 +97,39 @@ class Component(BaseComponent):
 
 
     @property
+    def todoItems(self):
+
+        out = []
+
+        try:
+
+            fgroupID = None
+            try:
+                fgroupID = self.getFindingGroup.id
+            except AttributeError:
+                try:
+                    fgroupID = UUID(str(self.findingGroup))
+                except ValueError:
+                    pass
+
+            for finding in self.report.findings:
+                findingFgroupID = None
+                try:
+                    findingFgroupID = UUID(str(finding.findingGroup))
+                except (AttributeError, ValueError):
+                    pass
+                if findingFgroupID == fgroupID:
+                    for item in finding.todoItems:
+                        out.append(f"{finding.name}: {item}")
+
+        except AttributeError as e:
+            # this report doesn't have findings
+            pass
+
+        return out
+
+
+    @property
     def iconColorDynamic(self):
     
         try:

--- a/writehat/components/base.py
+++ b/writehat/components/base.py
@@ -478,12 +478,8 @@ class BaseComponent():
             if getattr(v, "markdown", False):
                 match = re.search(todo_re, str(getattr(self, k, "")))
                 if match is not None:
-                    note = match.group("todo_note")
-                    if not note:
-                        note = "n/a"
-                    out.append(f"{k}: {note}")
-        log.debug(out)
-        return "\n".join(out)
+                    out.append(k)
+        return out
 
 
     @staticmethod

--- a/writehat/components/base.py
+++ b/writehat/components/base.py
@@ -15,6 +15,7 @@ from django.template.loader import get_template
 from writehat.lib.markdown import list_figures
 
 log = logging.getLogger(__name__)
+todo_re = r"\{\s{0,2}[Tt][Oo][Dd][Oo](?P<todo_note>[|][^}]+)?\s{0,2}\}"
 
 class caption(Enum):
     none = 0
@@ -467,6 +468,22 @@ class BaseComponent():
             return ReviewStatusField._choices[self.reviewStatus]
         except (KeyError, AttributeError):
             return ReviewStatusField._choices['unassigned']
+
+
+    @property
+    def todoItems(self):
+
+        out = []
+        for k,v in self.validFields().items():
+            if getattr(v, "markdown", False):
+                match = re.search(todo_re, str(getattr(self, k, "")))
+                if match is not None:
+                    note = match.group("todo_note")
+                    if not note:
+                        note = "n/a"
+                    out.append(f"{k}: {note}")
+        log.debug(out)
+        return "\n".join(out)
 
 
     @staticmethod

--- a/writehat/lib/finding.py
+++ b/writehat/lib/finding.py
@@ -12,6 +12,7 @@ from writehat.lib.revision import Revision
 
 
 log = logging.getLogger(__name__)
+todo_re = r"\{\s{0,2}[Tt][Oo][Dd][Oo](?P<todo_note>[|][^}]+)?\s{0,2}\}"
 
 class BaseDatabaseFinding(WriteHatBaseModel):
 
@@ -193,6 +194,22 @@ class BaseDatabaseFinding(WriteHatBaseModel):
             'name': 'Findings Database'
         }
 
+
+    @property
+    def todoFields(self):
+        out = []
+        for field in self._meta.get_fields():
+            try:
+                if field.markdown:
+                    log.debug(field.name)
+                    data = getattr(self, field.name, "")
+                    match = re.search(todo_re, data)
+                    if match is not None:
+                        out.append(field.name)
+            except AttributeError:
+                continue
+        log.debug(out)
+        return out
 
 
 class DREADFinding(BaseDatabaseFinding):

--- a/writehat/lib/finding.py
+++ b/writehat/lib/finding.py
@@ -196,7 +196,7 @@ class BaseDatabaseFinding(WriteHatBaseModel):
 
 
     @property
-    def todoFields(self):
+    def todoItems(self):
         out = []
         for field in self._meta.get_fields():
             try:
@@ -208,7 +208,6 @@ class BaseDatabaseFinding(WriteHatBaseModel):
                         out.append(field.name)
             except AttributeError:
                 continue
-        log.debug(out)
         return out
 
 

--- a/writehat/lib/markdown.py
+++ b/writehat/lib/markdown.py
@@ -69,6 +69,14 @@ reference_templates = {
         ),
         'allowed_fields': ('size'),
     },
+    'todo': {
+        'constructor': None,
+        'template': 'reportTemplates/blank.html',
+        'regex': re.compile(
+            r'{\s{0,2}[Tt][Oo][Dd][Oo](?P<todo_note>\|[^}]+)?\s{0,2}}'
+        ),
+        'allowed_fields': ('todo_note'),
+    },
 }
 
 # Tags allowed for rendering markdown

--- a/writehat/static/css/form.css
+++ b/writehat/static/css/form.css
@@ -80,6 +80,10 @@ table.writehat-form .btn-group button.n11:last-child { width: 12%;}
   margin-left: 2%;
 }
 
+.tooltipTodo {
+  display: inline;
+}
+
 /* checkboxes */
 table.writehat-form div.large-checkbox .custom-control-label::before,
 table.writehat-form div.large-checkbox .custom-control-label::after,

--- a/writehat/static/css/form.css
+++ b/writehat/static/css/form.css
@@ -41,6 +41,19 @@ table.writehat-form label {
   margin: 0rem;
 }
 
+table.writehat-form label.todo {
+  position: relative;
+}
+
+table.writehat-form label.todo::before {
+  position: absolute;
+  display: block;
+  left: -22px;
+  content: "\f06a";
+  font-family: "Font Awesome 5 Free";
+  color: orange;
+}
+
 table.writehat-form .container {
   padding: 0px;
 }

--- a/writehat/static/js/global.js
+++ b/writehat/static/js/global.js
@@ -310,6 +310,16 @@ function loadToolTips() {
       tooltipSelectModal.find('.modal-body').html(selectedTooltipText);
     });
   });
+  $('.tooltipTodo').click(function(e){
+    var componentId = $(e.currentTarget).attr('id').replace("tooltipTodo-", "");
+    loadModal('tooltipTodo', function(tooltipTodoModal) {
+      tooltipTodoModal.modal('show');
+      selectedTooltipText = $('#tooltipTodoText-'+componentId).html();
+      tooltipTodoModal.find('.modal-body').html(selectedTooltipText);
+      selectedTooltipTitle = $('#tooltipTodoTitle-'+componentId).html();
+      tooltipTodoModal.find('.modal-title').html(selectedTooltipTitle);
+    });
+  });
 };
 
 

--- a/writehat/static/js/markdown.js
+++ b/writehat/static/js/markdown.js
@@ -337,6 +337,19 @@ function highlightMono(editor) {
 }
 
 
+// 'todo' marker handling
+function checkTodoMarker(elem) {
+  var value = elem.getValue();
+  var editor = elem.getTextArea();
+  var label = $(editor).parent().siblings("th").children("label");
+  var regex = /\{\s{0,2}todo(\|[^}]+)?\s{0,2}\}/i;
+  console.log(value.match(regex));
+  if (value.match(regex)) {
+    label.addClass("todo");
+  } else {
+    label.removeClass("todo");
+  }
+}
 
 /* searches for textareas and turns them into markdown editors */
 function loadMarkdown() {
@@ -361,6 +374,9 @@ function loadMarkdown() {
       simplemde.codemirror.setOption("theme", "monokai");
       simplemde.codemirror.options.extraKeys['Tab'] = false;
       simplemde.codemirror.options.extraKeys['Shift-Tab'] = false;
+
+      simplemde.codemirror.on("blur", (elem => checkTodoMarker(elem)));
+      checkTodoMarker(simplemde.codemirror);
     })
   }
 

--- a/writehat/templates/modals/tooltipTodo.html
+++ b/writehat/templates/modals/tooltipTodo.html
@@ -1,0 +1,7 @@
+{% extends 'layouts/modal.html' %}
+
+{% block title %}TODO Items:{% endblock %}
+
+{% block body %}
+ <p>placeholder</p>
+{% endblock %}

--- a/writehat/templates/pages/componentReviewStatus.html
+++ b/writehat/templates/pages/componentReviewStatus.html
@@ -55,6 +55,11 @@
 {% block footer %}
 
 <script type='text/javascript' src='/static/js/componentReviewStatus.js'></script>
+<script type="text/javascript">
+  $().ready( function() {
+    loadToolTips();
+  });
+</script>
 <span id="engagement-info" engagement-id="{{ engagement.id }}" style="display: none;"></span>
 <span id="report-info" report-id="{{ report.id }}" style="display: none;"></span>
 {% endblock %}

--- a/writehat/templates/pages/findingGroupStatus.html
+++ b/writehat/templates/pages/findingGroupStatus.html
@@ -51,56 +51,72 @@
                   </a>
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if finding.description %}
+                  {% if "description" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.description %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if finding.affectedResources %}
+                  {% if "affectedResources" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.affectedResources %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if finding.impact %}
+                  {% if "impact" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.impact %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if finding.background %}
+                  {% if "background" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.background %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='cvss findingAttr'>
-                  {% if finding.proofOfConcept %}
+                  {% if "proofOfConcept" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.proofOfConcept %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='cvss findingAttr'>
-                  {% if finding.toolsUsed %}
+                  {% if "toolsUsed" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.toolsUsed %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='cvss dread findingAttr'>
-                  {% if finding.remediation %}
+                  {% if "remediation" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.remediation %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
                   {% endif %}
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if finding.references %}
+                  {% if "references" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.references %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
@@ -170,7 +186,9 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if finding.descDamage %}
+                  {% if "descDamage" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.descDamage %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
@@ -184,7 +202,9 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if finding.descReproducibility %}
+                  {% if "descReproducibility" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.descReproducibility %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
@@ -198,7 +218,9 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if finding.descExploitability %}
+                  {% if "descExploitability" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.descExploitability %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
@@ -212,7 +234,9 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if finding.descAffectedUsers %}
+                  {% if "descAffectedUsers" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.descAffectedUsers %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>
@@ -226,7 +250,9 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if finding.descDiscoverability %}
+                  {% if "descDiscoverability" in finding.todoFields %}
+                      <i class="text-warning fa fa-exclamation-circle"></i>
+                  {% elif finding.descDiscoverability %}
                       <i class="text-muted fa fa-check"></i>
                   {% else %}
                       <i class="text-danger fas fa-md fa-times-circle"></i>

--- a/writehat/templates/pages/findingGroupStatus.html
+++ b/writehat/templates/pages/findingGroupStatus.html
@@ -51,7 +51,7 @@
                   </a>
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if "description" in finding.todoFields %}
+                  {% if "description" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.description %}
                       <i class="text-muted fa fa-check"></i>
@@ -60,7 +60,7 @@
                   {% endif %}
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if "affectedResources" in finding.todoFields %}
+                  {% if "affectedResources" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.affectedResources %}
                       <i class="text-muted fa fa-check"></i>
@@ -69,7 +69,7 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if "impact" in finding.todoFields %}
+                  {% if "impact" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.impact %}
                       <i class="text-muted fa fa-check"></i>
@@ -78,7 +78,7 @@
                   {% endif %}
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if "background" in finding.todoFields %}
+                  {% if "background" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.background %}
                       <i class="text-muted fa fa-check"></i>
@@ -87,7 +87,7 @@
                   {% endif %}
               </td>
               <td class='cvss findingAttr'>
-                  {% if "proofOfConcept" in finding.todoFields %}
+                  {% if "proofOfConcept" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.proofOfConcept %}
                       <i class="text-muted fa fa-check"></i>
@@ -96,7 +96,7 @@
                   {% endif %}
               </td>
               <td class='cvss findingAttr'>
-                  {% if "toolsUsed" in finding.todoFields %}
+                  {% if "toolsUsed" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.toolsUsed %}
                       <i class="text-muted fa fa-check"></i>
@@ -105,7 +105,7 @@
                   {% endif %}
               </td>
               <td class='cvss dread findingAttr'>
-                  {% if "remediation" in finding.todoFields %}
+                  {% if "remediation" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.remediation %}
                       <i class="text-muted fa fa-check"></i>
@@ -114,7 +114,7 @@
                   {% endif %}
               </td>
               <td class='cvss dread proactive findingAttr'>
-                  {% if "references" in finding.todoFields %}
+                  {% if "references" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.references %}
                       <i class="text-muted fa fa-check"></i>
@@ -186,7 +186,7 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if "descDamage" in finding.todoFields %}
+                  {% if "descDamage" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.descDamage %}
                       <i class="text-muted fa fa-check"></i>
@@ -202,7 +202,7 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if "descReproducibility" in finding.todoFields %}
+                  {% if "descReproducibility" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.descReproducibility %}
                       <i class="text-muted fa fa-check"></i>
@@ -218,7 +218,7 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if "descExploitability" in finding.todoFields %}
+                  {% if "descExploitability" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.descExploitability %}
                       <i class="text-muted fa fa-check"></i>
@@ -234,7 +234,7 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if "descAffectedUsers" in finding.todoFields %}
+                  {% if "descAffectedUsers" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.descAffectedUsers %}
                       <i class="text-muted fa fa-check"></i>
@@ -250,7 +250,7 @@
                   {% endif %}
               </td>
               <td class='dread findingAttr'>
-                  {% if "descDiscoverability" in finding.todoFields %}
+                  {% if "descDiscoverability" in finding.todoItems %}
                       <i class="text-warning fa fa-exclamation-circle"></i>
                   {% elif finding.descDiscoverability %}
                       <i class="text-muted fa fa-check"></i>

--- a/writehat/templates/panes/reportComponents.html
+++ b/writehat/templates/panes/reportComponents.html
@@ -16,3 +16,8 @@
   </div>
 </div>
 <span id="page-info" page-name="{{ report.pageTemplate.name }}" page-id="{{ report.pageTemplateID }}" style="display: none;"></span>
+<script type="text/javascript">
+  $().ready( function() {
+    loadToolTips();
+  });
+</script>

--- a/writehat/templates/snippets/singleComponent.html
+++ b/writehat/templates/snippets/singleComponent.html
@@ -4,7 +4,7 @@
   <div style="text-align: center; width: 2rem; padding: .2rem">
     <i class="{{ component.iconType }}" style="color: {% if component.iconColorDynamic %}{{ component.iconColorDynamic }}{% else %}{{ component.iconColor }}{% endif %}"></i>
   </div>
-  <div class="componentName">{% if component.todoItems %}{% include 'snippets/smallButton.html' with class='tooltipTodo text-warning' id='tooltip-todo' type='exclamation-circle '%} {% endif %}{{ component.name }}</div>
+  <div class="componentName">{% if component.todoItems %}{% include 'widgets/tooltipTodo.html' with component_id=component.id component_name=component.name todo_items=component.todoItems %} {% endif %}{{ component.name }}</div>
   {% if editControls %}
     <div class="componentEditControls">
       <span class="assignee">{{ component.json.assignee_name }}</span>

--- a/writehat/templates/snippets/singleComponent.html
+++ b/writehat/templates/snippets/singleComponent.html
@@ -4,7 +4,7 @@
   <div style="text-align: center; width: 2rem; padding: .2rem">
     <i class="{{ component.iconType }}" style="color: {% if component.iconColorDynamic %}{{ component.iconColorDynamic }}{% else %}{{ component.iconColor }}{% endif %}"></i>
   </div>
-  <div class="componentName">{{ component.name }}</div>
+  <div class="componentName">{% if component.todoItems %}{% include 'snippets/smallButton.html' with class='tooltipTodo text-warning' id='tooltip-todo' type='exclamation-circle '%} {% endif %}{{ component.name }}</div>
   {% if editControls %}
     <div class="componentEditControls">
       <span class="assignee">{{ component.json.assignee_name }}</span>

--- a/writehat/templates/snippets/singleComponentStatus.html
+++ b/writehat/templates/snippets/singleComponentStatus.html
@@ -3,7 +3,7 @@
   <div style="text-align: center; width: 2rem; padding: .2rem">
     <i class="{{ component.iconType }}" style="color: {{ component.iconColor }}"></i>
   </div>
-  <div class='component-name'>{{ component.name }}</div>
+  <div class='component-name'>{% if component.todoItems %}{% include 'widgets/tooltipTodo.html' with component_id=component.id component_name=component.name todo_items=component.todoItems %} {% endif %}{{ component.name }}</div>
   {% if editControls %}
     <div class="componentEditControls">
       {% include 'snippets/smallButton.html' with name='Edit Component' type='pen' class='componentEdit text-dark' attrs='componentID='|addstr:component.id %}

--- a/writehat/templates/widgets/tooltipTodo.html
+++ b/writehat/templates/widgets/tooltipTodo.html
@@ -1,0 +1,10 @@
+{% load custom_tags %}
+{% include 'snippets/smallButton.html' with class='tooltipTodo text-warning' id='tooltipTodo-'|addstr:component_id type='exclamation-circle '%}
+<div id="tooltipTodoTitle-{{ component_id }}" style="display:none">TODO: {{ component_name }}</div>
+<div id="tooltipTodoText-{{ component_id }}" style="display:none">
+    <ul>
+      {% for item in todo_items %}
+          <li>{{ item }}</li>
+      {% endfor %}
+    </ul>
+</div>


### PR DESCRIPTION
Adds support for a "todo" marker within each Markdown field indicating unresolved items that require attention. These markers are denoted using an inline tag which has an optional notes field:

 * `{todo}`
 * `{todo|description goes here}`

The intention of this addition is to expedite the report review process, particularly for long documents or templated content containing placeholders. Unlike other tags, these markers are not rendered in the final report; they are instead diplayed in the editor UI in the following places:

 * Component and finding edit views, displayed as an icon next to the affected field's label. This icon is updated on page load and blur (e.g. loss of focus/clicking out of the field). Notably, it is currently not updated on component save to avoid hooking all keyUp events.
 * Report edit view, displayed as an icon next to the component's title. This icon indicates that one or more of the component's fields has a `{todo}` tag; clicking on the icon will display a modal which enumerates these fields. In the case of the Findings and Findings (Abridged) components, this list will denote the finding name as well as the affected field.
 * Findings status view, displayed as an icon within the table which otherwise indicates that the finding is complete or not yet started (using a checkmark or 'X', respectively).
 * Component review status view, displayed similar to the report edit view above.

Currently, modals which list the affected field use Writehat's internal representation of the field (e.g. a Markdown component diplays a list item indicating `text`). The "friendly name" associated with these fields is found only within the component's form. In the future this value should be read from the form, but currently the logic used to dereference fields within the model prevents such an addition.

Notably, this PR does not make any changes to Writehat's models, and makes only class-level changes to components. All other additions are either client-side or contained within the Django templates.

![TODO indicator on report edit view with modal](https://github.com/blacklanternsecurity/writehat/assets/26632151/035e8b2a-4abd-49d9-bae1-48f48e7a1f70)
![TODO indicator on component edit view, absent from render](https://github.com/blacklanternsecurity/writehat/assets/26632151/f2d47103-acdd-4704-b430-88e852e5cc70)
![TODO indicator on component edit view with note](https://github.com/blacklanternsecurity/writehat/assets/26632151/b8b06a61-2ff0-4e69-b635-c47f2b3e6157)
![TODO indicator on finding review status](https://github.com/blacklanternsecurity/writehat/assets/26632151/7a9175b4-49ce-430b-8681-bfee3be1d4b6)
![TODO indicator on review status dashboard](https://github.com/blacklanternsecurity/writehat/assets/26632151/34417aef-fd04-4adb-abc9-6de140a7cd8f)