### PR TITLE
Add "Today" button to Title Page component date field

### DIFF
--- a/writehat/components/TitlePage.py
+++ b/writehat/components/TitlePage.py
@@ -5,12 +5,14 @@ from datetime import datetime
 current_year = datetime.now().year
 years = range(current_year-5, current_year+5)
 
-
 class TitlePageForm(ComponentForm):
+    class CustomDateWidget(forms.SelectDateWidget):
+        template_name = "widgets/custom_date.html"
+
    # ComponentID = forms.UUIDField(label='Report ID')
     company = forms.CharField(label='Company Name', required=False)
     assessmentType = forms.CharField(label='Report Title', required=False)
-    reportDate = forms.DateTimeField(widget=forms.SelectDateWidget(years=years), label='Report Date', required=False)
+    reportDate = forms.DateTimeField(widget=CustomDateWidget(years=years), label='Report Date', required=False)
 
 
 class Component(BaseComponent):

--- a/writehat/components/TitlePageShort.py
+++ b/writehat/components/TitlePageShort.py
@@ -7,6 +7,8 @@ years = range(current_year-5, current_year+5)
 
 
 class Component(TitlePageComponent):
+    class CustomDateWidget(forms.SelectDateWidget):
+        template_name = "widgets/custom_date.html"
 
     default_name = 'Title Page (Abridged)'
     htmlTemplate = 'componentTemplates/TitlePageShort.html'

--- a/writehat/templates/widgets/custom_date.html
+++ b/writehat/templates/widgets/custom_date.html
@@ -1,0 +1,12 @@
+{% include 'django/forms/widgets/multiwidget.html' %} <a href="#id_reportDate_day" id="set_today_val">Today</span>
+
+<script type="text/javascript">
+  $().ready(function() {
+    $("#set_today_val").click( function() {
+      const date = new Date();
+      $("#id_reportDate_month").val(date.getMonth() + 1);
+      $("#id_reportDate_day").val(date.getDate());
+      $("#id_reportDate_year").val(date.getFullYear());
+    });
+  });
+</script>


### PR DESCRIPTION
This PR adds a button to the "Title Page" and "Title Page (Abridged)" components which sets the current value of the Date fields to today's date. It uses a custom widget template which adds a javascript-driven hyperlink to the existing template, then subclasses the `SelectDateWidget` class to use the modified template.