### PR TITLE
Allow "start" attribute on ordered list tags

### DIFF
--- a/writehat/lib/markdown.py
+++ b/writehat/lib/markdown.py
@@ -100,6 +100,7 @@ markdown_attrs = {
     'th': ['align'],
     'td': ['align', 'finding-severity'],
     'hl': ['purple', 'pink', 'red', 'orange', 'yellow', 'green', 'blue', 'gray', 'mono'], # custom color highlights
+    'ol': ['start'],
 }
 
 


### PR DESCRIPTION
Allow the `start` attribute to specified when creating an HTML-formatted ordered list (`<ol>`) in a Markdown field.