### PR TITLE
Render fixes

### DIFF
--- a/writehat/static/css/report/report_fixes.css
+++ b/writehat/static/css/report/report_fixes.css
@@ -1,0 +1,5 @@
+/* used to make an element invisible but still take up space on the page.
+helpful for when extra padding needs to be added after a screwy render */
+.hidden-padding-fix {
+    visibility: hidden;
+}

--- a/writehat/static/js/engagementEdit.js
+++ b/writehat/static/js/engagementEdit.js
@@ -9,7 +9,6 @@ function updateFindingPrefix() {
 }
 
 function saveState() {
-  console.log("SAVED");
   var status = {};
   $(".btn-save-state").each(function() {
     status[$(this).attr("id")] = $(this).prop("checked");
@@ -57,8 +56,21 @@ $(document).ready(function() {
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    var itemStatus = data[4];
-    return $(`input[name='status'][value='${itemStatus}']:checked`).length === 1;
+    if (settings.nTable.id !== "reports") {
+      return true
+    }
+
+    let wrapper = $(settings.nTableWrapper)
+
+    let itemStatus = data[4];
+    let name = data[0]
+    let query = wrapper.find('[type="search"]').val()
+
+    selected_status = $(`input[name='status'][value='${itemStatus}']:checked`).length === 1;
+    searched_name = name.indexOf(query) != -1
+
+    return selected_status && searched_name
+
   });
 
   var table = $('#reports').DataTable();

--- a/writehat/static/js/savedReports.js
+++ b/writehat/static/js/savedReports.js
@@ -24,8 +24,21 @@ $(document).ready(function() {
 
   // Custom range filtering function
   $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-    var itemStatus = data[4];
-    return $(`input[name='status'][value='${itemStatus}']:checked`).length === 1;
+    if (settings.nTable.id !== "reports") {
+      return true
+    }
+
+    let wrapper = $(settings.nTableWrapper)
+
+    let itemStatus = data[4];
+    let name = data[0].toLowerCase()
+    let query = wrapper.find('[type="search"]').val().toLowerCase()
+
+    selected_status = $(`input[name='status'][value='${itemStatus}']:checked`).length === 1;
+    searched_name = name.indexOf(query) != -1
+
+    return selected_status && searched_name
+
   });
   
   var table = $('#reports').DataTable();

--- a/writehat/templates/reportTemplates/reportDependencies.html
+++ b/writehat/templates/reportTemplates/reportDependencies.html
@@ -2,6 +2,7 @@
 <link rel='stylesheet' href='/static/css/report/print.css' />
 <link rel='stylesheet' href='/static/css/component/TableOfContents.css' />
 <link rel='stylesheet' href='/static/css/report/interface.css' />
+<link rel='stylesheet' href='/static/css/report/report_fixes.css' />
 
 <script type="text/javascript">
     window.PagedConfig = {


### PR DESCRIPTION
# Summary

## Report Tables Filter Fixed

Fixes an issue with pull request https://github.com/blacklanternsecurity/writehat/pull/91 where the datatable search function was being applied to every other datatable on the page, regardless of it being the intended table. A check is now made that the reports table filter logic only happens for tables with `id=reports`.

## Report CSS fixes file

A css file has been added to the report template that adds css elements specifically for the purpose of making handling weird edge cases or formatting issues. This is more of a band-aid than anything, but you do what you must. these can be inserted into markdown content as html tags like so:

`<span class="fix-thing">some content</span>`

It is not necessary to use a span tag, it is just used for demonstration purposes.