### PR TITLE
Implemented retest feature

### DIFF
--- a/writehat/components/FindingsStatusList.py
+++ b/writehat/components/FindingsStatusList.py
@@ -1,0 +1,11 @@
+import logging
+from .base import *
+
+log = logging.getLogger(__name__)
+
+class Component(BaseComponent):
+
+    default_name = 'Summary of Findings Status'
+    htmlTemplate = 'componentTemplates/FindingsStatusList.html'
+    iconType = 'fas fa-th-list'
+    iconColor = 'var(--orange)'

--- a/writehat/lib/finding.py
+++ b/writehat/lib/finding.py
@@ -26,6 +26,17 @@ class BaseDatabaseFinding(WriteHatBaseModel):
     background = MarkdownField(max_length=30000, null=True, blank=True)
     remediation = MarkdownField(max_length=30000, null=True, blank=True)
     references = MarkdownField(max_length=30000, null=True, blank=True)
+    retest = MarkdownField(max_length=30000, null=True, blank=True)
+    # status choices
+    status_choices = (
+    ("Open", "Open"),
+    ("Partially Fixed", "Partially Fixed"),
+    ("Risk Accepted", "Risk Accepted"),
+    ("Fixed", "Fixed"),
+    ("Not Fixed", "Not Fixed"),
+    ("Closed", "Closed"),
+)
+    status = models.CharField(max_length=30, choices=status_choices, default="Open")
 
     # Overridden by child class
     scoringType = models.CharField(default='None', max_length=50)

--- a/writehat/lib/findingForm.py
+++ b/writehat/lib/findingForm.py
@@ -29,11 +29,30 @@ class FindingForm(forms.Form):
         max_length=30000,
         required=False)
 
+    retest = forms.CharField(
+        label='Retest',
+        widget=forms.Textarea(),
+        max_length=30000,
+        required=False)
+
     categoryID = forms.UUIDField(
         label='Category',
         widget=CategoryBootstrapSelectEngagements(
             attrs={'required': 'true'}
         ),
+        required=True)
+
+    #vulnerability status
+    statusChoices = (
+    ("Open", "Open"),
+    ("Partially Fixed", "Partially Fixed"),
+    ("Risk Accepted", "Risk Accepted"),
+    ("Fixed", "Fixed"),
+    ("Not Fixed", "Not Fixed"),
+    ("Closed", "Closed")
+    )
+    status = forms.ChoiceField(choices=statusChoices,
+        label='Status',
         required=True)
 
     @property
@@ -420,7 +439,7 @@ class EngagementFindingForm(forms.Form):
 class CVSSEngagementFindingForm(EngagementFindingForm,CVSSForm):
 
     findingGroup = forms.UUIDField(label='Finding Group',required=True)
-    field_order = ['name','findingGroup','categoryID','description','affectedResources','background','proofOfConcept','toolsUsed','remediation','references','cvssAV','cvssAC','cvssPR','cvssUI','cvssS','cvssC','cvssI','cvssA','cvssE','cvssRL','cvssRC','cvssCR','cvssIR','cvssAR','cvssMAV','cvssMAC','cvssMPR','cvssMUI','cvssMS','cvssMC','cvssMI','cvssMA',]
+    field_order = ['name','status','findingGroup','categoryID','description','affectedResources','background','proofOfConcept','retest','toolsUsed','remediation','references','cvssAV','cvssAC','cvssPR','cvssUI','cvssS','cvssC','cvssI','cvssA','cvssE','cvssRL','cvssRC','cvssCR','cvssIR','cvssAR','cvssMAV','cvssMAC','cvssMPR','cvssMUI','cvssMS','cvssMC','cvssMI','cvssMA',]
 
 
 class DREADEngagementFindingForm(EngagementFindingForm,DREADForm):
@@ -452,12 +471,14 @@ class DREADEngagementFindingForm(EngagementFindingForm,DREADForm):
 
     field_order = [
         'name',
+        'status',
         'findingGroup',
         'categoryID',
         'description',
         'affectedResources',
         'dreadImpact',
         'background',
+        'retest',
         'remediation',
         'references',
         'dreadDamage',
@@ -476,7 +497,7 @@ class DREADEngagementFindingForm(EngagementFindingForm,DREADForm):
 class ProactiveEngagementFindingForm(EngagementFindingForm,ProactiveForm):
 
     findingGroup = forms.UUIDField(label='Finding Group',required=True)
-    field_order = ['name','findingGroup','categoryID','description','affectedResources','background','references']
+    field_order = ['name','status','findingGroup','categoryID','description','affectedResources','background','retest','references']
 
 
 class CVSSDatabaseFindingForm(CVSSForm):

--- a/writehat/static/css/component/FindingsList.css
+++ b/writehat/static/css/component/FindingsList.css
@@ -150,10 +150,12 @@ div.finding-content > div.impact ul li {
   margin: 4px;
 }
 
+div.finding div.finding-content > div.status::before             { content: "Status" !important; }
 div.finding div.finding-content > div.category::before           { content: "Category" !important; }
 div.finding div.finding-content > div.affected-resources::before { content: "Affected Resources" !important; }
 div.finding div.finding-content > div.description::before        { content: "Description" !important; }
 div.finding div.finding-content > div.background::before         { content: "Background" !important; }
+div.finding div.finding-content > div.retest::before             { content: "Retest" !important; }
 div.finding div.finding-content > div.remediation::before        { content: "Remediation" !important; }
 div.finding div.finding-content > div.references::before         { content: "References" !important; }
 

--- a/writehat/static/css/component/FindingsStatusList.css
+++ b/writehat/static/css/component/FindingsStatusList.css
@@ -1,0 +1,89 @@
+div.finding-group-name {
+    padding: .5em;
+    margin: .5em;
+    font-weight: bold;
+    font-size: 1.1em;
+    width: 100%;
+    text-align: center;
+  }
+  
+  p.findings-status-summary-entry {
+      padding: .5rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      margin: 0 10rem 2px calc(2rem + 4px);
+      position: relative;
+      background-color: #BEDDBA;
+  }
+  
+  p.findings-status-summary-entry::before {
+      content: '';
+      padding: 1rem;
+      position: absolute;
+      background-color: #7BB274;
+      display: inline-block;
+      left: calc(-2rem - 2px);
+      bottom: 0;
+      top: 0;
+  }
+
+  p.findings-status-summary-entry::after {
+    content: attr(finding-status);
+    padding: .5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    position: absolute;
+    background-color: #BEDDBA;
+    display: inline-block;
+    left: calc(36.8rem + 2px);
+    bottom: 0;
+    top: 0;
+    color: black;
+    font-weight: bold;
+    font-size: 16px;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 8rem;
+    text-align: center;
+}
+  
+  p.findings-status-summary-entry a {
+      text-decoration: none;
+      color: black;
+      font-weight: bold;
+      font-size: 16px;
+  }
+
+  p.findings-status-summary-title-entry {
+    color: black;
+    padding: .5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    margin: 0 10rem 2px calc(2rem + 4px);
+    position: relative;
+    text-decoration: none;
+    color: black;
+    font-weight: bold;
+    font-size: 16px;
+}
+
+  p.findings-status-summary-title-entry::after {
+    content: 'Status';
+    padding: .5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    position: absolute;
+    background-color: #ffffff;
+    display: inline-block;
+    left: calc(36.8rem + 2px);
+    bottom: 0;
+    top: 0;
+    color: black;
+    font-weight: bold;
+    font-size: 16px;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 8rem;
+    text-align: center;
+}
+

--- a/writehat/templates/componentTemplates/CVSSFinding.html
+++ b/writehat/templates/componentTemplates/CVSSFinding.html
@@ -17,6 +17,13 @@
             </div>
         </div>
     {% endif %}
+    {% if showStatus %}
+    <div class='finding-content'>
+        <div class='status' style='font-weight: bold'>
+            {{ finding.status }}
+        </div>
+    </div>
+    {% endif %}
     <div class='finding-content'>
         <div class='category' style='font-weight: bold'>
             {{ finding.categoryFull }}
@@ -54,6 +61,13 @@
         <div class='finding-content'>
             <div class='poc'>
                 {% markdown finding.proofOfConcept %}
+            </div>
+        </div>
+    {% endif %}
+    {% if finding.retest %}
+        <div class='finding-content'>
+            <div class='retest'>
+                {% markdown finding.retest %}
             </div>
         </div>
     {% endif %}

--- a/writehat/templates/componentTemplates/DREADFinding.html
+++ b/writehat/templates/componentTemplates/DREADFinding.html
@@ -10,6 +10,13 @@
             [{{ finding.number }}] {{ finding.name }}
         </div>
     </div>
+    {% if showStatus %}
+    <div class='finding-content'>
+        <div class='status' style='font-weight: bold'>
+            {{ finding.status }}
+        </div>
+    </div>
+    {% endif %}
     <div class='finding-content'>
         <div class='category' style='font-weight: bold'>
             {{ finding.categoryFull }}
@@ -91,6 +98,13 @@
             D:{{ finding.dread.dict.dreadDiscoverability }}
             ) / 5 = {{ finding.score }} ({{ finding.severity }}) </div>
     </div>
+    {% if finding.retest %}
+    <div class='finding-content'>
+        <div class='retest'>
+            {% markdown finding.retest %}
+        </div>
+    </div>
+    {% endif %}
     {% if finding.remediation %}
         <div class='finding-content'>
             <div class='remediation'>

--- a/writehat/templates/componentTemplates/FindingsStatusList.html
+++ b/writehat/templates/componentTemplates/FindingsStatusList.html
@@ -1,0 +1,24 @@
+<section class="l{{ level }} component {% if pageBreakBefore %} page-break{% endif %}">
+    {% include 'componentTemplates/Heading.html' with name=name %}
+
+      {% for fgroup in report.ordered_fgroups %}
+    
+        <!-- Only include the title if there are findings -->
+        {% if fgroup.findings %}
+        <div class='finding-group-name'>
+          {{ fgroup.name }}
+        </div>
+        <p class="findings-status-summary-title-entry" finding-status-title="Status">
+          Finding
+        </p>
+        {% for finding in fgroup %}
+          {% if not report.finding_uuids or finding.id in report.finding_uuids %}
+            <p class="findings-status-summary-entry" finding-status="{{ finding.status }}">
+              <a href="#finding-{{ finding.id }}">[{{ finding.number }}] {{ finding.name }}</a>
+            </p>
+          {% endif %}
+        {% endfor %}
+
+        {% endif %}
+      {% endfor %}
+    </section>

--- a/writehat/templates/componentTemplates/ProactiveFinding.html
+++ b/writehat/templates/componentTemplates/ProactiveFinding.html
@@ -5,9 +5,16 @@
             {{ finding.severity }}
         </div>
         <div class='finding-title'>
-            [{{ finding.number }}] {{ finding.name }}
+            {% if showFindingNumbers %}[{{ finding.number }}] {% endif %}{{ finding.name }}
         </div>
     </div>
+    {% if showStatus %}
+    <div class='finding-content'>
+        <div class='status' style='font-weight: bold'>
+            {{ finding.status }}
+        </div>
+    </div>
+    {% endif %}
     <div class='finding-content'>
         <div class='category' style='font-weight: bold'>
             {{ finding.categoryFull }}
@@ -33,6 +40,13 @@
                 {% markdown finding.background %}
             </div>
         </div>
+    {% endif %}
+    {% if finding.retest %}
+    <div class='finding-content'>
+        <div class='retest'>
+            {% markdown finding.retest %}
+        </div>
+    </div>
     {% endif %}
     {% if finding.references %}
         <div class='finding-content'>


### PR DESCRIPTION
I have implemented a retest feature into Writehat which allows you to record and present the results from any vulnerability retesting that might occur for that engagement. 

The following things have been added:

* A status option toggle has been added for each finding (open, fixed, not fixed, risk accepted, etc.)
* A retest field has been added to each finding for recording results of the retest
* A toggle has been added to the FIndings component which allows you to enable or disable the status for a particular finding group
* A new component has been added for summarising the retest results:

![image](https://github.com/blacklanternsecurity/writehat/assets/5217665/4d07a39b-b8d1-4dee-8355-0a70f6b35e40)
